### PR TITLE
Fix list navigation at boundaries

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -292,18 +292,54 @@ impl App {
     }
 
     pub fn select_next(&mut self) {
-        self.todo_list.state.select_next();
+        if self.todo_list.items.is_empty() {
+            self.todo_list.state.select(None);
+            return;
+        }
+
+        let next_index = match self.todo_list.state.selected() {
+            Some(i) => {
+                if i >= self.todo_list.items.len().saturating_sub(1) {
+                    i
+                } else {
+                    i + 1
+                }
+            }
+            None => 0,
+        };
+        self.todo_list.state.select(Some(next_index));
     }
     pub fn select_previous(&mut self) {
-        self.todo_list.state.select_previous();
+        if self.todo_list.items.is_empty() {
+            self.todo_list.state.select(None);
+            return;
+        }
+
+        let prev_index = match self.todo_list.state.selected() {
+            Some(i) => {
+                if i == 0 {
+                    0
+                } else {
+                    i - 1
+                }
+            }
+            None => 0,
+        };
+        self.todo_list.state.select(Some(prev_index));
     }
 
     pub fn select_first(&mut self) {
-        self.todo_list.state.select_first();
+        if !self.todo_list.items.is_empty() {
+            self.todo_list.state.select(Some(0));
+        }
     }
 
     pub fn select_last(&mut self) {
-        self.todo_list.state.select_last();
+        if !self.todo_list.items.is_empty() {
+            self.todo_list
+                .state
+                .select(Some(self.todo_list.items.len() - 1));
+        }
     }
 
     /// Changes the status of the selected list item

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -69,7 +69,7 @@ mod tests {
         handle_key(&mut app, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         assert_eq!(
             app.todo_list.state.selected(),
-            Some(3),
+            Some(2),
             "Expected selection to remain at the last task"
         );
     }


### PR DESCRIPTION
## Summary
- keep cursor on boundary when navigating
- update the selection boundary test
- avoid selecting when list is empty

## Testing
- `cargo build --quiet`
- `cargo test handlers::tests::test_handle_key_task_list_mode -- --color=never`
- `cargo test tui::tests::test_init_terminal -- --color=never` *(fails: terminal crash)*

------
https://chatgpt.com/codex/tasks/task_e_684a95b3bd7c83209f3c3a4ee97cca96